### PR TITLE
Undefined references to dl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 
 set(CMAKE_DEBUG_POSTFIX "-d")
 add_library(luabind ${LUABIND_SRCS} ${LUABIND_API} ${LUABIND_DETAIL_API})
-target_link_libraries(luabind ${LUA_LIBRARIES} ${LUABIND_EXTRA_LIBS})
+target_link_libraries(luabind ${LUA_LIBRARIES} ${LUABIND_EXTRA_LIBS} ${CMAKE_DL_LIBS})
 set_property(TARGET
     luabind PROPERTY
     COMPILE_FLAGS


### PR DESCRIPTION
Hello,

I encountered a problem with linking, when building it on Ubuntu:

Linking CXX executable test_abstract_base
/usr/local/lib/liblua.a(loadlib.o): In function `lookforfunc':
loadlib.c:(.text+0x4a1): undefined reference to `dlsym'
loadlib.c:(.text+0x4e1): undefined reference to `dlerror'
loadlib.c:(.text+0x516): undefined reference to `dlopen'
loadlib.c:(.text+0x583): undefined reference to `dlerror'
/usr/local/lib/liblua.a(loadlib.o): In function `gctm':
loadlib.c:(.text+0x6f8): undefined reference to `dlclose'

Quick fix was to link the dl libs.

Regards