### PR TITLE
Replace deprecated auto_ptr with unique_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ else()
         list(APPEND possible_flags
             Wall
             Wextra
-            Wno-deprecated-declarations # auto_ptr is OK for now
             Wno-unused-macros
             Wlogical-op
             Wmissing-declarations

--- a/doc/classes.rst
+++ b/doc/classes.rst
@@ -416,7 +416,7 @@ where:
 * ``p`` is an instance of ``P``
 
 ``get_pointer()`` overloads are provided for the smart pointers in
-Boost, and ``std::auto_ptr<>``. Should you need to provide your own
+Boost, and ``std::unique_ptr<>``. Should you need to provide your own
 overload, note that it is called unqualified and is expected to be found
 by *argument dependent lookup*. Thus it should be defined in the same
 namespace as the pointer type it operates on.
@@ -433,9 +433,9 @@ Will cause luabind to hold any instance created on the Lua side in a
 will be held by a ``boost::scoped_ptr<X>``. If, for example, you
 register a function::
 
-    std::auto_ptr<X> make_X();
+    std::unique_ptr<X> make_X();
 
-the instance returned by that will be held in ``std::auto_ptr<X>``. This
+the instance returned by that will be held in ``std::unique_ptr<X>``. This
 is handled automatically for all smart pointers that implement a
 ``get_pointer()`` overload.
 
@@ -451,7 +451,7 @@ is handled automatically for all smart pointers that implement a
 
     .. parsed-literal::
 
-      bool is_non_null(std::auto_ptr<X> const& p)
+      bool is_non_null(std::unique_ptr<X> const& p)
       {
           return p.get();
       }

--- a/luabind/adopt_policy.hpp
+++ b/luabind/adopt_policy.hpp
@@ -92,7 +92,7 @@ namespace luabind { namespace detail
     template <class T>
     struct pointer_or_default<void, T>
     {
-        typedef std::auto_ptr<T> type;
+        typedef std::unique_ptr<T> type;
     };
 
     template <class Pointer>

--- a/luabind/class.hpp
+++ b/luabind/class.hpp
@@ -304,7 +304,7 @@ namespace luabind
         template <class T>
         struct default_pointer<null_type, T>
         {
-            typedef std::auto_ptr<T> type;
+            typedef std::unique_ptr<T> type;
         };
 
         template <class Class, class Pointer, class Signature, class Policies>

--- a/luabind/detail/constructor.hpp
+++ b/luabind/detail/constructor.hpp
@@ -45,7 +45,7 @@ struct construct_aux<0, T, Pointer, Signature>
     {
         object_rep* self = touserdata<object_rep>(self_);
 
-        std::auto_ptr<T> instance(new T);
+        std::unique_ptr<T> instance(new T);
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -54,7 +54,7 @@ struct construct_aux<0, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr));
+            std::move(ptr), registered_class<T>::id, naked_ptr));
     }
 };
 
@@ -90,7 +90,7 @@ struct construct_aux<N, T, Pointer, Signature>
     {
         object_rep* self = touserdata<object_rep>(self_);
 
-        std::auto_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
+        std::unique_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -99,7 +99,7 @@ struct construct_aux<N, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr));
+            std::move(ptr), registered_class<T>::id, naked_ptr));
     }
 };
 

--- a/luabind/detail/has_get_pointer.hpp
+++ b/luabind/detail/has_get_pointer.hpp
@@ -58,7 +58,7 @@ namespace has_get_pointer_
   T* get_pointer(T const volatile*);
 
   template<class T>
-  T* get_pointer(std::auto_ptr<T> const&);
+  T* get_pointer(std::unique_ptr<T> const&);
 
 # endif
 

--- a/luabind/detail/instance_holder.hpp
+++ b/luabind/detail/instance_holder.hpp
@@ -52,7 +52,7 @@ inline mpl::true_ check_const_pointer(void const*)
 }
 
 template <class T>
-void release_ownership(std::auto_ptr<T>& p)
+void release_ownership(std::unique_ptr<T>& p)
 {
     p.release();
 }
@@ -78,7 +78,7 @@ public:
         P p, class_id dynamic_id, void* dynamic_ptr
     )
       : instance_holder(check_const_pointer(false ? get_pointer(p) : 0))
-      , m_p(p)
+      , m_p(std::move(p))
       , m_weak(0)
       , m_dynamic_id(dynamic_id)
       , m_dynamic_ptr(dynamic_ptr)

--- a/luabind/detail/make_instance.hpp
+++ b/luabind/detail/make_instance.hpp
@@ -89,7 +89,7 @@ void make_instance(lua_State* L, P p)
 
     try
     {
-        new (storage) holder_type(p, dynamic.first, dynamic.second);
+        new (storage) holder_type(std::move(p), dynamic.first, dynamic.second);
     }
     catch (...)
     {

--- a/luabind/detail/policy.hpp
+++ b/luabind/detail/policy.hpp
@@ -176,7 +176,7 @@ namespace luabind { namespace detail
     {
         if (get_pointer(x))
         {
-            make_instance(L, x);
+            make_instance(L, std::move(x));
         }
         else
         {
@@ -187,8 +187,8 @@ namespace luabind { namespace detail
     template <class T>
     void make_pointee_instance(lua_State* L, T& x, mpl::false_, mpl::true_)
     {
-        std::auto_ptr<T> ptr(new T(x));
-        make_instance(L, ptr);
+        std::unique_ptr<T> ptr(new T(x));
+        make_instance(L, std::move(ptr));
     }
 
     template <class T>

--- a/luabind/function.hpp
+++ b/luabind/function.hpp
@@ -44,7 +44,7 @@ namespace detail
 template <class F, class Policies>
 scope def(char const* name, F f, Policies const& policies)
 {
-    return scope(std::auto_ptr<detail::registration>(
+    return scope(std::unique_ptr<detail::registration>(
         new detail::function_registration<F, Policies>(name, f, policies)));
 }
 

--- a/luabind/scope.hpp
+++ b/luabind/scope.hpp
@@ -59,7 +59,7 @@ namespace luabind {
     struct LUABIND_API scope
     {
         scope();
-        explicit scope(std::auto_ptr<detail::registration> reg);
+        explicit scope(std::unique_ptr<detail::registration> reg);
         scope(scope const& other_);
         ~scope();
 

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -233,7 +233,7 @@ namespace luabind { namespace detail {
     // -- interface ---------------------------------------------------------
 
     class_base::class_base(char const* name_)
-        : scope(std::auto_ptr<registration>(
+        : scope(std::unique_ptr<registration>(
                 m_registration = new class_registration(name_))
           )
     {
@@ -256,14 +256,14 @@ namespace luabind { namespace detail {
 
     void class_base::add_member(registration* member)
     {
-        std::auto_ptr<registration> ptr(member);
-        m_registration->m_members.operator,(scope(ptr));
+        std::unique_ptr<registration> ptr(member);
+        m_registration->m_members.operator,(scope(std::move(ptr)));
     }
 
     void class_base::add_default_member(registration* member)
     {
-        std::auto_ptr<registration> ptr(member);
-        m_registration->m_default_members.operator,(scope(ptr));
+        std::unique_ptr<registration> ptr(member);
+        m_registration->m_default_members.operator,(scope(std::move(ptr)));
     }
 
     const char* class_base::name() const

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -49,7 +49,7 @@ namespace luabind { namespace detail {
     {
     }
 
-    scope::scope(std::auto_ptr<detail::registration> reg)
+    scope::scope(std::unique_ptr<detail::registration> reg)
         : m_chain(reg.release())
     {
     }
@@ -199,7 +199,7 @@ namespace luabind {
     };
 
     namespace_::namespace_(char const* name)
-        : scope(std::auto_ptr<detail::registration>(
+        : scope(std::unique_ptr<detail::registration>(
               m_registration = new registration_(name)))
     {
     }

--- a/test/test_automatic_smart_ptr.cpp
+++ b/test/test_automatic_smart_ptr.cpp
@@ -59,9 +59,9 @@ X* get_pointer(ptr const& p)
     return p.p;
 }
 
-std::auto_ptr<X> make1()
+std::unique_ptr<X> make1()
 {
-    return std::auto_ptr<X>(new X(1));
+    return std::unique_ptr<X>(new X(1));
 }
 
 boost::shared_ptr<X> make2()

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -43,14 +43,14 @@ struct Unregistered : Base
     {}
 };
 
-std::auto_ptr<Base> make_derived()
+std::unique_ptr<Base> make_derived()
 {
-    return std::auto_ptr<Base>(new Derived);
+    return std::unique_ptr<Base>(new Derived);
 }
 
-std::auto_ptr<Base> make_unregistered()
+std::unique_ptr<Base> make_unregistered()
 {
-    return std::auto_ptr<Base>(new Unregistered);
+    return std::unique_ptr<Base>(new Unregistered);
 }
 
 } // namespace unnamed

--- a/test/test_lua_classes.cpp
+++ b/test/test_lua_classes.cpp
@@ -306,12 +306,12 @@ void test_main(lua_State* L)
             );
     }
 
-    std::auto_ptr<base> own_ptr;
+    std::unique_ptr<base> own_ptr;
     {
         LUABIND_CHECK_STACK(L);
 
         TEST_NOTHROW(
-            own_ptr = std::auto_ptr<base>(
+            own_ptr = std::unique_ptr<base>(
                 call_function<base*>(L, "make_derived") [ adopt(result) ])
             );
     }
@@ -328,11 +328,11 @@ void test_main(lua_State* L)
     TEST_NOTHROW(
         TEST_CHECK(own_ptr->f() == "derived:f() : base:f()")
     );
-    own_ptr = std::auto_ptr<base>();
+    own_ptr = std::unique_ptr<base>();
 
     // test virtual functions that are not overridden by lua
     TEST_NOTHROW(
-        own_ptr = std::auto_ptr<base>(
+        own_ptr = std::unique_ptr<base>(
             call_function<base*>(L, "make_empty_derived") [ adopt(result) ])
         );
     TEST_NOTHROW(


### PR DESCRIPTION
Hello,

I thought it would be nice to get rid of those warnings by replacing deprecated std::auto_ptr with std::unique_ptr. I replaced it everywhere and inserted some std::move in order to make it work. I ran all tests from the directory and they behave the same as before. I also did some simple tests in my project. What do you think?

Regards,
Michał