### PR TITLE
Fixed: Compilation issues on macOS Clang compiler.

### DIFF
--- a/luabind/detail/open.hpp
+++ b/luabind/detail/open.hpp
@@ -26,18 +26,11 @@
 
 #include <luabind/config.hpp>
 
+// Predeclaration
+struct lua_State;
+
 namespace luabind
 {
-    namespace detail
-    {
-        LUABIND_API void add_operator_to_metatable(lua_State* L, int op_index);
-        LUABIND_API int create_cpp_class_metatable(lua_State* L);
-        LUABIND_API int create_cpp_instance_metatable(lua_State* L);
-        LUABIND_API int create_lua_class_metatable(lua_State* L);
-        LUABIND_API int create_lua_instance_metatable(lua_State* L);
-        LUABIND_API int create_lua_function_metatable(lua_State* L);
-    }
-
     LUABIND_API void open(lua_State* L);
 }
 


### PR DESCRIPTION
 - Added lua_State predeclaration.
 - Removed dead code from detail/open.hpp:
   * add_operator_to_metatable(), create_cpp_instance_metatable(), create_lua_instance_metatable(), create_lua_function_metatable() - no calls anywhere.
   * create_cpp_class_metatable(), create_lua_class_metatable() - only called from the functions below. Moreover implementations are in anonymous namespace so there is compilation Clang error about ambiguous call.