### PR TITLE
fix test fail when define LUABIND_NO_EXCEPTIONS

### DIFF
--- a/test/test_free_functions.cpp
+++ b/test/test_free_functions.cpp
@@ -140,7 +140,7 @@ void test_main(lua_State* L)
         call_function<void>(L, "failing_fun");
         TEST_ERROR("function didn't fail when it was expected to");
     }
-    catch (luabind::error const&)
+    catch(std::exception const&)
     {
         if (std::string("[string \"function failing_fun() error('expected "
 #if LUA_VERSION_NUM >= 502

--- a/test/test_lua_classes.cpp
+++ b/test/test_lua_classes.cpp
@@ -240,7 +240,7 @@ void test_main(lua_State* L)
         LUABIND_CHECK_STACK(L);
 
         try { call_function<int>(L, "gen_error"); }
-        catch (luabind::error&)
+        catch (std::exception&)
         {
             bool result(
                 lua_tostring(L, -1) == std::string("[string \"function "
@@ -261,7 +261,7 @@ void test_main(lua_State* L)
         LUABIND_CHECK_STACK(L);
 
         try { call_function<void>(L, "gen_error"); }
-        catch (luabind::error&)
+        catch (std::exception&)
         {
             bool result(
                 lua_tostring(L, -1) == std::string("[string \"function "
@@ -275,7 +275,7 @@ void test_main(lua_State* L)
         LUABIND_CHECK_STACK(L);
 
         try { call_function<void>(L, "gen_error") [ adopt(result) ]; }
-        catch (luabind::error&)
+        catch (std::exception&)
         {
             bool result(
                 lua_tostring(L, -1) == std::string("[string \"function "

--- a/test/test_package_preload.cpp
+++ b/test/test_package_preload.cpp
@@ -73,7 +73,7 @@ void test_main(lua_State* L)
     DOSTRING(L, "package.preload = nil");
     try {
         set_package_preload(L, "failmod", &loader);
-    } catch (luabind::error const&) {
+    } catch (std::exception const&) {
         TEST_CHECK(std::strcmp("attempt to index a nil value", lua_tostring(L, -1)) == 0);
         lua_pop(L, 1);
         return;


### PR DESCRIPTION
When define LUABIND_NO_EXCEPTIONS,luabind::error will not be defined,so the test will fail.In principle, the test should be rewritten, but it seems that it can be modified easily.