### PR TITLE
pcall: port to lua-5.4

### DIFF
--- a/src/pcall.cpp
+++ b/src/pcall.cpp
@@ -48,7 +48,10 @@ namespace luabind { namespace detail
 
     int resume_impl(lua_State *L, int nargs, int)
     {
-#if LUA_VERSION_NUM >= 502
+#if LUA_VERSION_NUM >= 504
+        int nresults;
+        int res = lua_resume(L, NULL, nargs, &nresults);
+#elif LUA_VERSION_NUM >= 502
         int res = lua_resume(L, NULL, nargs);
 #else
         int res = lua_resume(L, nargs);


### PR DESCRIPTION
lua 5.4 changes the `lua_resume` API:

```
The function lua_resume has an extra parameter. This out parameter
returns the number of values on the top of the stack that were yielded
or returned by the coroutine. (In previous versions, those values were
the entire stack.)
```

https://www.lua.org/manual/5.4/manual.html#8.3

this patch is similar to the implementation in the sol bindings