### PR TITLE
object_rep: use `aligned_storage` when possible

### DIFF
--- a/luabind/detail/object_rep.hpp
+++ b/luabind/detail/object_rep.hpp
@@ -28,7 +28,11 @@
 #include <luabind/detail/class_rep.hpp>
 #include <luabind/detail/instance_holder.hpp>
 
+#ifdef BOOST_NO_CXX11_HDR_TYPE_TRAITS
 #include <boost/aligned_storage.hpp>
+#else
+#include <type_traits>
+#endif
 
 namespace luabind { namespace detail
 {
@@ -98,7 +102,11 @@ namespace luabind { namespace detail
         void operator=(object_rep const&);
 
         BOOST_STATIC_CONSTANT(std::size_t, instance_buffer_size=32);
+#ifdef BOOST_NO_CXX11_HDR_TYPE_TRAITS
         boost::aligned_storage<instance_buffer_size> m_instance_buffer;
+#else
+        std::aligned_storage<instance_buffer_size, alignof (size_t)> m_instance_buffer;
+#endif
         instance_holder* m_instance;
         class_rep* m_classrep; // the class information about this object's type
         std::size_t m_dependency_cnt; // counts dependencies


### PR DESCRIPTION
the culprit here is that `boost::aligned_storage` has an
`alignof(int128_t)` but the memory allocated by lua is only aligned by
the standard alignment. `std::aligned_storage` however has an alignment
of 1 so it is safe to allocate.

this fixes ubsan warnings like:
```
src/object_rep.cpp:263:61: runtime error: constructor call on misaligned address 0x55f9e96fa6a8 for type 'struct object_rep', which requires 16 byte alignment
    0x55f9e96fa6a8: note: pointer points here
     00 00 00 00  12 00 00 00 db 00 00 00  69 00 00 00 74 00 00 00  31 00 00 00 00 00 00 00  80 06 7a ec
```