### PR TITLE
Lua 5.3 bitwise operator support.

### DIFF
--- a/luabind/detail/operator_id.hpp
+++ b/luabind/detail/operator_id.hpp
@@ -44,6 +44,12 @@ namespace luabind { namespace detail {
         op_tostring,
         op_concat,
         op_len,
+        op_band,
+        op_bor,
+        op_bxor,
+        op_bnot,
+        op_shl,
+        op_shr,
 
         number_of_operators
     };
@@ -53,7 +59,8 @@ namespace luabind { namespace detail {
         static const char* a[number_of_operators] = {
             "__add", "__sub", "__mul", "__div", "__mod", "__pow",
             "__lt", "__le", "__eq", "__call", "__unm",
-            "__tostring", "__concat", "__len" };
+            "__tostring", "__concat", "__len",
+            "__band", "__bor", "__bxor", "__bnot", "__shl", "__shr" };
         return a[i];
     }
 
@@ -62,7 +69,8 @@ namespace luabind { namespace detail {
         static const char* a[number_of_operators] = {
             "+", "-", "*", "/", "%", "^", "<",
             "<=", "==", "()", "- (unary)",
-            "tostring", "..", "#" };
+            "tostring", "..", "#",
+            "&", "|", "~", "~ (unary)", "<<", ">>" };
         return a[i];
     }
 

--- a/luabind/operator.hpp
+++ b/luabind/operator.hpp
@@ -293,6 +293,11 @@ namespace luabind {
     LUABIND_BINARY_OPERATOR(lt, <)
     LUABIND_BINARY_OPERATOR(le, <=)
     LUABIND_BINARY_OPERATOR(eq, ==)
+    LUABIND_BINARY_OPERATOR(band, &)
+    LUABIND_BINARY_OPERATOR(bor, |)
+    // LUABIND_BINARY_OPERATOR(bxor, ^) -- Already used for pow.
+    LUABIND_BINARY_OPERATOR(shl, <<)
+    LUABIND_BINARY_OPERATOR(shr, >>)
 
 #undef LUABIND_BINARY_OPERATOR
 
@@ -343,6 +348,7 @@ namespace luabind {
 
     LUABIND_UNARY_OPERATOR(tostring, tostring_operator, tostring)
     LUABIND_UNARY_OPERATOR(unm, -, operator-)
+    LUABIND_UNARY_OPERATOR(bnot, ~, operator~)
 
 #undef LUABIND_UNARY_OPERATOR
 

--- a/src/object_rep.cpp
+++ b/src/object_rep.cpp
@@ -296,7 +296,7 @@ namespace luabind { namespace detail
         {
             lua_pushstring(L, get_operator_name(op));
             lua_pushvalue(L, -1);
-            lua_pushboolean(L, op == op_unm || op == op_len); // Unary?
+            lua_pushboolean(L, op == op_unm || op == op_len || op == op_bnot); // Unary?
             lua_pushcclosure(L, &dispatch_operator, 2);
             lua_rawset(L, -3);
         }

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -66,6 +66,36 @@ float operator%(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
     return 15.f;
 }
 
+std::string operator&(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
+{
+    return "bitwise and operator";
+}
+
+std::string operator|(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
+{
+    return "bitwise or operator";
+}
+
+std::string operator^(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
+{
+    return "bitwise xor operator";
+}
+
+std::string operator~(operator_tester const& /*lhs*/)
+{
+    return "bitwise not operator";
+}
+
+std::string operator<<(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
+{
+    return "left shift operator";
+}
+
+std::string operator>>(operator_tester const& /*lhs*/, operator_tester const& /*rhs*/)
+{
+    return "right shift operator";
+}
+
 std::string operator*(operator_tester const&, int)
 {
     return "(operator_tester, int) overload";
@@ -149,6 +179,12 @@ void test_main(lua_State* L)
             .def(const_self * const_self)
             .def(const_self * other<int>())
             .def(const_self % const_self)
+            .def(const_self & const_self)
+            .def(const_self | const_self)
+            .def("__bxor", static_cast<std::string(*)(operator_tester const&, operator_tester const&)>(&operator^))
+            .def(~const_self)
+            .def(const_self << const_self)
+            .def(const_self >> const_self)
 //          .def("clone", &clone, adopt(return_value)),
         ,
 
@@ -193,6 +229,12 @@ void test_main(lua_State* L)
     DOSTRING(L, "assert(test * test == 35)");
     DOSTRING(L, "assert(test % test == 15)");
     DOSTRING(L, "assert(test * 3 == '(operator_tester, int) overload')")
+    DOSTRING(L, "assert(test & test == 'bitwise and operator')")
+    DOSTRING(L, "assert(test | test == 'bitwise or operator')")
+    DOSTRING(L, "assert(test ~ test == 'bitwise xor operator')")
+    DOSTRING(L, "assert(~test == 'bitwise not operator')")
+    DOSTRING(L, "assert(test << test == 'left shift operator')")
+    DOSTRING(L, "assert(test >> test == 'right shift operator')")
     DOSTRING(L, "assert(test + test2 == 73)");
     DOSTRING(L, "assert(2 + test == 2 + 2)");
     DOSTRING(L, "assert(test + 2 == 1 + 2)");


### PR DESCRIPTION
Add support for Lua 5.3's bitwise operators (and, or, xor, not, shl, shr). 

XOR is a bit awkward to use, since its operator is already abused for pow.
For example:
`.def("__bxor", static_cast<std::string(*)(operator_tester const&, operator_tester const&)>(&operator^))`