### PR TITLE
 Used unique_ptr instead of auto_ptr when c++11 is used -- help change the syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,17 +44,25 @@ if(NOT LUA_FOUND AND NOT LUA51_FOUND AND NOT LUA52_FOUND)
     set(LUA_INCLUDE_DIRS "${LUA_INCLUDE_DIR}")
 endif()
 
+set(LUABIND_CPP_STANDARD "c++14" CACHE STRING "Choose the cpp version for the project, including c++03, c++11, c++14, c++17")
+set_property(CACHE LUABIND_CPP_STANDARD PROPERTY STRINGS c++03 c++11 c++14 c++17)
+
 if(NOT MSVC)
     check_cxx_compiler_flag(-std=c++11 LUABIND_HAS_CXX11)
-    if (LUABIND_HAS_CXX11)
-        set (LUABIND_CXX11_COMPILER_FLAGS "-std=c++11")
-    else()
-        message("Compiler does not support -std=c++11 flag, C++11 disabled.")
-    endif()
+    check_cxx_compiler_flag(-std=c++14 LUABIND_HAS_CXX14)
+    # if (LUABIND_HAS_CXX11)
+    #     set (LUABIND_CXX11_COMPILER_FLAGS "-std=c++11")
+    # elseif(LUABIND_HAS_CXX14)
+    #     set (LUABIND_CXX14_COMPILER_FLAGS "-std=c++14")
+    # else()
+    #     message("Compiler does not support -std=c++11 flag, C++11 disabled.")
+    # endif()
 elseif(MSVC_VERSION GREATER 1699) # 1700 = VS 11 (2012)
     set (LUABIND_HAS_CXX11 ON)
+    set (LUABIND_HAS_CXX14 ON)
 else()
     set (LUABIND_HAS_CXX11 OFF)
+    set (LUABIND_HAS_CXX14 OFF)
     message("MSVC < 11 (2012) detected, C++11 disabled.")
 endif()
 
@@ -68,11 +76,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     option(LUABIND_DYNAMIC_LINK "Build luabind as a shared library?" OFF)
     option(LUABIND_NOT_THREADSAFE "Permit the use of static variables, thus making Luabind usable only from one of your system threads." OFF)
     option(LUABIND_ENABLE_WARNINGS "Enable extra warnings during the build of the library and tests" ON)
-    if (LUABIND_HAS_CXX11)
-        option(LUABIND_USE_CXX11 "Build Luabind using C++11 features?" ON)
-    else()
-        set(LUABIND_USE_CXX11 OFF)
-    endif()
 
     if(Boost_VERSION LESS 104700)
         set(LUABIND_USE_NOEXCEPT_DEF OFF)
@@ -84,16 +87,16 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         unset(LUABIND_USE_NOEXCEPT_DEF)
     endif()
 
-    if(LUABIND_USE_CXX11 AND NOT LUABIND_HAS_CXX11)
-        # The compiler supports no C++11
-        set(LUABIND_USE_CXX11 OFF CACHE BOOL "Build Luabind using C++11 features?" FORCE)
+    if( NOT(LUABIND_CPP_STANDARD STREQUAL "c++03") AND NOT (LUABIND_HAS_CXX11 OR LUABIND_HAS_CXX14 ) )
+        # The compiler supports no C++11 and C++14
+        set(LUABIND_CPP_STANDARD "c++03" CACHE STRING "Build Luabind using C++11 features?" FORCE)
     endif()
 
-    if(LUABIND_USE_CXX11)
+    if( NOT(LUABIND_CPP_STANDARD STREQUAL "c++03") )
         option(LUABIND_NO_SCOPED_ENUM "Indicates that your compiler and standard library lacks scoped enums and std::underlying_type" OFF)
         set(LUABIND_NO_STD_SHARED_PTR OFF)
     else()
-        # No CXX11, can't have scoped enum
+        # No CXX11 and CXX14 , can't have scoped enum
         # TODO is this right?
         #set(LUABIND_NO_SCOPED_ENUM ON CACHE INTERNAL "" FORCE)
         option(LUABIND_NO_STD_SHARED_PTR "Indicates that your standard library lacks C++11 shared_ptr in std namespace" ON)
@@ -112,11 +115,14 @@ configure_file(build_information.hpp.cmake_in "${CMAKE_CURRENT_BINARY_DIR}/luabi
 # Set up the build
 set(BUILD_SHARED_LIBS ${LUABIND_DYNAMIC_LINK})
 
-if(LUABIND_USE_CXX11 AND LUABIND_CXX11_COMPILER_FLAGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LUABIND_CXX11_COMPILER_FLAGS}")
-elseif(NOT LUABIND_USE_CXX11 AND NOT MSVC)
+if( NOT (LUABIND_CPP_STANDARD STREQUAL "c++03" ) )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=${LUABIND_CPP_STANDARD}")
+else()
+    check_cxx_compiler_flag(-std=c++03 LUABIND_HAS_CXX03FLAG)
     check_cxx_compiler_flag(-std=c++98 LUABIND_HAS_CXX98FLAG)
-    if (LUABIND_HAS_CXX98FLAG)
+    if (LUABIND_HAS_CXX03FLAG)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+    elseif(LUABIND_HAS_CXX98FLAG)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
     endif()
 endif()
@@ -187,7 +193,7 @@ else()
             Wstrict-overflow=5)
 
 
-        if(LUABIND_USE_CXX11)
+        if( NOT (LUABIND_CPP_STANDARD STREQUAL "c++03" ) )
             list(APPEND possible_flags Wnoexcept)
         endif()
 
@@ -203,7 +209,7 @@ else()
                 Wno-exit-time-destructors
                 Wno-missing-noreturn)
 
-            if(LUABIND_USE_CXX11)
+            if( NOT (LUABIND_CPP_STANDARD STREQUAL "c++03" ) )
                list(APPEND possible_flags
                     Wno-zero-as-nullpointer
                     Wno-c++98-compat
@@ -213,7 +219,7 @@ else()
                     Wno-c++11-long-long)
             endif()
 
-        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT LUABIND_USE_CXX11)
+        elseif( (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (LUABIND_CPP_STANDARD STREQUAL "c++03" ) )
             list(APPEND possible_flags Wno-long-long)
         endif()
 

--- a/luabind/adopt_policy.hpp
+++ b/luabind/adopt_policy.hpp
@@ -27,6 +27,7 @@
 #include <luabind/back_reference_fwd.hpp>
 #include <luabind/config.hpp>
 #include <luabind/detail/policy.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <luabind/wrapper_base.hpp>
 
 #include <boost/type_traits/is_polymorphic.hpp>
@@ -96,7 +97,7 @@ namespace luabind { namespace detail
     template <class T>
     struct pointer_or_default<void, T>
     {
-        typedef std::auto_ptr<T> type;
+        typedef luabind::unique_ptr<T> type;
     };
 
     template <class Pointer>

--- a/luabind/class.hpp
+++ b/luabind/class.hpp
@@ -87,6 +87,7 @@
 #include <luabind/detail/signature_match.hpp>
 #include <luabind/detail/typetraits.hpp>
 #include <luabind/function.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <luabind/no_dependency.hpp>
 #include <luabind/scope.hpp>
 #include <luabind/typeid.hpp>
@@ -304,7 +305,7 @@ namespace luabind
         template <class T>
         struct default_pointer<null_type, T>
         {
-            typedef std::auto_ptr<T> type;
+            typedef luabind::unique_ptr<T> type;
         };
 
         template <class Class, class Pointer, class Signature, class Policies>

--- a/luabind/detail/constructor.hpp
+++ b/luabind/detail/constructor.hpp
@@ -10,6 +10,7 @@
 #  include <luabind/detail/inheritance.hpp>
 #  include <luabind/get_main_thread.hpp>
 #  include <luabind/detail/object.hpp>
+#  include <luabind/luabind_memory.hpp>
 #  include <luabind/wrapper_base.hpp>
 
 #  include <boost/preprocessor/iteration/iterate.hpp>
@@ -44,8 +45,7 @@ struct construct_aux<0, T, Pointer, Signature>
     void operator()(argument const& self_) const
     {
         object_rep* self = touserdata<object_rep>(self_);
-
-        std::auto_ptr<T> instance(new T);
+        luabind::unique_ptr<T> instance(new T);
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -54,7 +54,7 @@ struct construct_aux<0, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr));
+            luabind::move(ptr), registered_class<T>::id, naked_ptr));
     }
 };
 
@@ -90,7 +90,7 @@ struct construct_aux<N, T, Pointer, Signature>
     {
         object_rep* self = touserdata<object_rep>(self_);
 
-        std::auto_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
+        luabind::unique_ptr<T> instance(new T(BOOST_PP_ENUM_PARAMS(N,_)));
         inject_backref(self_.interpreter(), instance.get(), instance.get());
 
         void* naked_ptr = instance.get();
@@ -99,7 +99,7 @@ struct construct_aux<N, T, Pointer, Signature>
         void* storage = self->allocate(sizeof(holder_type));
 
         self->set_instance(new (storage) holder_type(
-            ptr, registered_class<T>::id, naked_ptr));
+            luabind::move(ptr), registered_class<T>::id, naked_ptr));
     }
 };
 

--- a/luabind/detail/has_get_pointer.hpp
+++ b/luabind/detail/has_get_pointer.hpp
@@ -26,6 +26,9 @@
 # include <boost/type_traits/add_reference.hpp>
 # include <boost/mpl/bool.hpp>
 
+// Jlee 2021-07-21 not sure BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP,
+//  memory has already include in luabind_memory.hpp
+# include <luabind/luabind_memory.hpp>
 # ifndef BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP
 #  include <memory>
 # endif
@@ -59,8 +62,7 @@ namespace has_get_pointer_
   T* get_pointer(T const volatile*);
 
   template<class T>
-  T* get_pointer(std::auto_ptr<T> const&);
-
+  T* get_pointer(luabind::unique_ptr<T> const&);
 # endif
 
 //

--- a/luabind/detail/instance_holder.hpp
+++ b/luabind/detail/instance_holder.hpp
@@ -7,6 +7,7 @@
 
 # include <luabind/detail/inheritance.hpp>
 # include <luabind/get_pointer.hpp>
+# include <luabind/luabind_memory.hpp>
 # include <luabind/typeid.hpp>
 
 # include <boost/type_traits/is_polymorphic.hpp>
@@ -52,7 +53,7 @@ inline mpl::true_ check_const_pointer(void const*)
 }
 
 template <class T>
-void release_ownership(std::auto_ptr<T>& p)
+void release_ownership(luabind::unique_ptr<T>& p)
 {
     p.release();
 }
@@ -78,7 +79,7 @@ public:
         P p, class_id dynamic_id, void* dynamic_ptr
     )
       : instance_holder(check_const_pointer(false ? get_pointer(p) : 0))
-      , m_p(p)
+      , m_p(luabind::move(p))
       , m_weak(0)
       , m_dynamic_id(dynamic_id)
       , m_dynamic_ptr(dynamic_ptr)

--- a/luabind/detail/make_instance.hpp
+++ b/luabind/detail/make_instance.hpp
@@ -7,6 +7,7 @@
 
 # include <luabind/detail/inheritance.hpp>
 # include <luabind/detail/object_rep.hpp>
+#include <luabind/luabind_memory.hpp>
 
 # include <boost/type_traits/is_polymorphic.hpp>
 
@@ -89,7 +90,7 @@ void make_instance(lua_State* L, P p)
 
     try
     {
-        new (storage) holder_type(p, dynamic.first, dynamic.second);
+        new (storage) holder_type(luabind::move(p), dynamic.first, dynamic.second);
     }
     catch (...)
     {

--- a/luabind/detail/policy.hpp
+++ b/luabind/detail/policy.hpp
@@ -59,6 +59,7 @@
 #include <luabind/detail/primitives.hpp>
 #include <luabind/detail/typetraits.hpp>
 #include <luabind/from_stack.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <luabind/value_wrapper.hpp>
 #include <luabind/weak_ref.hpp>
 
@@ -178,7 +179,7 @@ namespace luabind { namespace detail
     {
         if (get_pointer(x))
         {
-            make_instance(L, x);
+            make_instance(L, luabind::move(x));
         }
         else
         {
@@ -189,8 +190,8 @@ namespace luabind { namespace detail
     template <class T>
     void make_pointee_instance(lua_State* L, T& x, mpl::false_, mpl::true_)
     {
-        std::auto_ptr<T> ptr(new T(x));
-        make_instance(L, ptr);
+        luabind::unique_ptr<T> ptr(new T(x));
+        make_instance(L, luabind::move(ptr));
     }
 
     template <class T>

--- a/luabind/function.hpp
+++ b/luabind/function.hpp
@@ -7,6 +7,7 @@
 
 # include <luabind/detail/call_function.hpp>
 # include <luabind/make_function.hpp>
+#include <luabind/luabind_memory.hpp>
 # include <luabind/scope.hpp>
 
 namespace luabind {
@@ -44,8 +45,8 @@ namespace detail
 template <class F, class Policies>
 scope def(char const* name, F f, Policies const& policies)
 {
-    return scope(std::auto_ptr<detail::registration>(
-        new detail::function_registration<F, Policies>(name, f, policies)));
+  return scope(luabind::unique_ptr<detail::registration>(
+    new detail::function_registration<F, Policies>(name, f, policies)));
 }
 
 template <class F>

--- a/luabind/luabind_memory.hpp
+++ b/luabind/luabind_memory.hpp
@@ -1,0 +1,20 @@
+#ifndef LUABIND_MEMORY_HPP_INCLUDED
+#define LUABIND_MEMORY_HPP_INCLUDED
+
+# include <memory>
+
+namespace luabind{
+
+#if __cplusplus >= 201103L
+    using std::unique_ptr;
+    using std::move;
+#else
+    using unique_ptr = std::auto_ptr;
+    template<typename T>
+    T move(T ptr){
+        return ptr;
+    }
+#endif
+}
+
+#endif

--- a/luabind/scope.hpp
+++ b/luabind/scope.hpp
@@ -28,6 +28,7 @@
 #include <luabind/object.hpp>
 
 #include <luabind/lua_state_fwd.hpp>
+#include <luabind/luabind_memory.hpp>
 
 #include <memory>
 
@@ -59,13 +60,20 @@ namespace luabind {
     struct LUABIND_API scope
     {
         scope();
-        explicit scope(std::auto_ptr<detail::registration> reg);
+        explicit scope(luabind::unique_ptr<detail::registration> reg);
         scope(scope const& other_);
         ~scope();
 
         scope& operator=(scope const& other_);
 
-        scope& operator,(scope s);
+        /* Oberon00 2020-05-24
+        * Reading the implementation in scope.cpp of this, I'm concerned.
+        * Was a simple def("foo", &foo), def("bar", &bar) previously causing a double-delete?
+        * Would scope& without const work here, similar to
+        * https://en.cppreference.com/w/cpp/memory/auto_ptr/auto_ptr ? */
+        // Jlee 2021-07-21 Not sure this patch usage
+        // scope& operator,(scope s);
+        scope& operator,(const scope& s);
 
         void register_(lua_State* L) const;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(LUABIND_API
     ../luabind/luabind.hpp
     ../luabind/lua_include.hpp
     ../luabind/lua_state_fwd.hpp
+    ../luabind/luabind_memory.hpp
     ../luabind/make_function.hpp
     ../luabind/nil.hpp
     ../luabind/no_dependency.hpp

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -24,6 +24,7 @@
 
 #include <luabind/class.hpp>
 #include <luabind/config.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <luabind/nil.hpp>
 
 #include <boost/foreach.hpp>
@@ -233,7 +234,7 @@ namespace luabind { namespace detail {
     // -- interface ---------------------------------------------------------
 
     class_base::class_base(char const* name_)
-        : scope(std::auto_ptr<registration>(
+         : scope(luabind::unique_ptr<registration>(
                 m_registration = new class_registration(name_))
           )
     {
@@ -256,14 +257,14 @@ namespace luabind { namespace detail {
 
     void class_base::add_member(registration* member)
     {
-        std::auto_ptr<registration> ptr(member);
-        m_registration->m_members.operator,(scope(ptr));
+        luabind::unique_ptr<registration> ptr(member);
+        m_registration->m_members.operator,(scope(luabind::move(ptr)));
     }
 
     void class_base::add_default_member(registration* member)
     {
-        std::auto_ptr<registration> ptr(member);
-        m_registration->m_default_members.operator,(scope(ptr));
+        luabind::unique_ptr<registration> ptr(member);
+        m_registration->m_default_members.operator,(scope(luabind::move(ptr)));
     }
 
     const char* class_base::name() const

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -25,7 +25,7 @@
 #include <luabind/detail/debug.hpp>
 #include <luabind/detail/stack_utils.hpp>
 #include <luabind/scope.hpp>
-
+#include <luabind/luabind_memory.hpp>
 #include <luabind/lua_include.hpp>
 
 #include <cassert>
@@ -48,8 +48,7 @@ namespace luabind { namespace detail {
         : m_chain(0)
     {
     }
-
-    scope::scope(std::auto_ptr<detail::registration> reg)
+    scope::scope(luabind::unique_ptr<detail::registration> reg)
         : m_chain(reg.release())
     {
     }
@@ -199,7 +198,7 @@ namespace luabind {
     };
 
     namespace_::namespace_(char const* name)
-        : scope(std::auto_ptr<detail::registration>(
+         : scope(luabind::unique_ptr<detail::registration>(
               m_registration = new registration_(name)))
     {
     }

--- a/test/test_automatic_smart_ptr.cpp
+++ b/test/test_automatic_smart_ptr.cpp
@@ -4,6 +4,7 @@
 
 #include "test.hpp"
 #include <luabind/luabind.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace {
@@ -58,10 +59,9 @@ X* get_pointer(ptr const& p)
 {
     return p.p;
 }
-
-std::auto_ptr<X> make1()
+luabind::unique_ptr<X> make1()
 {
-    return std::auto_ptr<X>(new X(1));
+    return luabind::unique_ptr<X>(new X(1));
 }
 
 boost::shared_ptr<X> make2()

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -4,6 +4,7 @@
 
 #include "test.hpp"
 #include <luabind/luabind.hpp>
+#include <luabind/luabind_memory.hpp>
 
 namespace {
 
@@ -43,14 +44,14 @@ struct Unregistered : Base
     {}
 };
 
-std::auto_ptr<Base> make_derived()
+luabind::unique_ptr<Base> make_derived()
 {
-    return std::auto_ptr<Base>(new Derived);
+    return luabind::unique_ptr<Base>(new Derived);
 }
 
-std::auto_ptr<Base> make_unregistered()
+luabind::unique_ptr<Base> make_unregistered()
 {
-    return std::auto_ptr<Base>(new Unregistered);
+    return luabind::unique_ptr<Base>(new Unregistered);
 }
 
 } // namespace unnamed

--- a/test/test_lua_classes.cpp
+++ b/test/test_lua_classes.cpp
@@ -24,6 +24,7 @@
 
 #include <luabind/adopt_policy.hpp>
 #include <luabind/luabind.hpp>
+#include <luabind/luabind_memory.hpp>
 #include <luabind/wrapper_base.hpp>
 
 #include <boost/shared_ptr.hpp>
@@ -343,15 +344,13 @@ void test_main(lua_State* L)
             call_function<void>(make_derived)
             );
     }
-
-    std::auto_ptr<base> own_ptr;
+    luabind::unique_ptr<base> own_ptr;
     {
         LUABIND_CHECK_STACK(L);
-
         TEST_NOTHROW(
-            own_ptr = std::auto_ptr<base>(
-                call_function<base*>(L, "make_derived") [ adopt(result) ])
-            );
+             own_ptr = luabind::unique_ptr<base>(
+                 call_function<base*>(L, "make_derived") [ adopt(result) ])
+             );
     }
 
     // make sure the derived lua-part is still referenced by
@@ -366,13 +365,12 @@ void test_main(lua_State* L)
     TEST_NOTHROW(
         TEST_CHECK(own_ptr->f() == "derived:f() : base:f()")
     );
-    own_ptr = std::auto_ptr<base>();
-
+    own_ptr = luabind::unique_ptr<base>();
     // test virtual functions that are not overridden by lua
     TEST_NOTHROW(
-        own_ptr = std::auto_ptr<base>(
+        own_ptr = luabind::unique_ptr<base>(
             call_function<base*>(L, "make_empty_derived") [ adopt(result) ])
-        );
+    );
     TEST_NOTHROW(
         TEST_CHECK(own_ptr->f() == "base:f()")
     );


### PR DESCRIPTION
Hi @Oberon00,

We recently has been working on deprecating auto_ptr usage for our projects. I noticed that Bertram25 has been a while since updating the request. After reviewing some of your thoughts and his changes, we finished building the project and hope to contribute our work to this repo.