### PR TITLE
Fixes alignment assumption in `object_rep` placement new

### DIFF
--- a/luabind/detail/object_rep.hpp
+++ b/luabind/detail/object_rep.hpp
@@ -97,8 +97,10 @@ namespace luabind { namespace detail
 
         void operator=(object_rep const&);
 
+        struct cD { char c; union { LUAI_MAXALIGN; } u; };
         BOOST_STATIC_CONSTANT(std::size_t, instance_buffer_size=32);
-        boost::aligned_storage<instance_buffer_size> m_instance_buffer;
+        BOOST_STATIC_CONSTANT(std::size_t, instance_buffer_align=offsetof(struct cD, u));
+        boost::aligned_storage<instance_buffer_size, instance_buffer_align> m_instance_buffer;
         instance_holder* m_instance;
         class_rep* m_classrep; // the class information about this object's type
         std::size_t m_dependency_cnt; // counts dependencies

--- a/luabind/detail/object_rep.hpp
+++ b/luabind/detail/object_rep.hpp
@@ -97,7 +97,11 @@ namespace luabind { namespace detail
 
         void operator=(object_rep const&);
 
+#ifdef LUAI_MAXALIGN
         struct cD { char c; union { LUAI_MAXALIGN; } u; };
+#else
+        struct cD { char c; union { lua_Number n; double u; void *s; lua_Integer i; long l; } u; };
+#endif
         BOOST_STATIC_CONSTANT(std::size_t, instance_buffer_size=32);
         BOOST_STATIC_CONSTANT(std::size_t, instance_buffer_align=offsetof(struct cD, u));
         boost::aligned_storage<instance_buffer_size, instance_buffer_align> m_instance_buffer;


### PR DESCRIPTION
The `object_rep` class is allocated and initialized as follows:

```
void* storage = lua_newuserdata(L, sizeof(object_rep));
object_rep* result = new (storage) object_rep(0, cls);
```

The class also contains the following member:

```
boost::aligned_storage<instance_buffer_size> m_instance_buffer;
```

The alignment guarantee of `lua_newuserdata` can be found from:

```
struct cD { char c; union { LUAI_MAXALIGN; } u; };
const int maxalign = offsetof(struct cD, u);
```

This is likely 8 bytes.

The alignment of boost::aligned_storage can be found from `alignof(std::max_align_t)`.

This may be either 8 or 16 bytes, depending on the platform.

When the class is aligned to 16 bytes, `movaps` may be used by the compiler, as the compiler assumes the allocation has the specified alignment.

But when the allocation is only aligned to 8 bytes at the same time, this causes an alignment crash in the constructor called during placement new.

Patch applies the correct alignment guarantee of `lua_newuserdata` to the storage.